### PR TITLE
Add Coolify credential

### DIFF
--- a/credentials/CoolifyApi.credentials.ts
+++ b/credentials/CoolifyApi.credentials.ts
@@ -1,0 +1,45 @@
+import {
+	IAuthenticateGeneric,
+	ICredentialTestRequest,
+	ICredentialType,
+	INodeProperties,
+} from 'n8n-workflow';
+
+export class CoolifyApi implements ICredentialType {
+	name = 'coolifyApi';
+	displayName = 'Coolify API';
+
+	properties: INodeProperties[] = [
+		{
+			displayName: 'Base URL',
+			name: 'baseUrl',
+			type: 'string',
+			default: 'https://app.coolify.io',
+		},
+		{
+			displayName: 'Token',
+			name: 'token',
+			type: 'string',
+			default: '',
+			typeOptions: {
+				password: true,
+			},
+		},
+	];
+
+	authenticate: IAuthenticateGeneric = {
+		type: 'generic',
+		properties: {
+			headers: {
+				Authorization: '={{"Bearer " + $credentials.token}}',
+			},
+		},
+	};
+
+	test: ICredentialTestRequest = {
+		request: {
+			baseURL: '={{$credentials.baseUrl}}',
+			url: '/api/v1/version',
+		},
+	};
+}

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "n8nNodesApiVersion": 1,
     "credentials": [
       "dist/credentials/ExampleCredentialsApi.credentials.js",
-      "dist/credentials/HttpBinApi.credentials.js"
+      "dist/credentials/HttpBinApi.credentials.js",
+      "dist/credentials/CoolifyApi.credentials.js"
     ],
     "nodes": [
       "dist/nodes/ExampleNode/ExampleNode.node.js",


### PR DESCRIPTION
Add Coolify API credential support.

* **credentials/CoolifyApi.credentials.ts**
  - Define `CoolifyApi` class implementing `ICredentialType`
  - Set `name` to 'coolifyApi' and `displayName` to 'Coolify API'
  - Add `baseUrl` and `token` properties in `properties` array
  - Implement `authenticate` method using `IAuthenticateGeneric` with Bearer token
  - Implement `test` method using `ICredentialTestRequest` to test the credentials

* **package.json**
  - Add `dist/credentials/CoolifyApi.credentials.js` to `n8n.credentials` array

Resoves #1

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/gemboran/n8n-nodes-gemboran/pull/2?shareId=1787a459-4d41-4c04-a25c-017f747644e6).